### PR TITLE
Add support for 19-digit Discord IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Allows messaging from FoundryVTT to Discord through webhooks.
 ## Getting Started
 First, you'll need to create a webhook for the channel you want to send messages to. <a href="https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks">This guide</a>  goes over the basics of webhooks and how to set one up. Copy the Webhook URL and add it to the "Discord Webhook" field in the module settings.
 
-Next, for each of your players, add their corresponding Discord ID (Not UserName#1234, Right click them in Discord and select "Copy ID" at the bottom) to their User Configuration view. This will be an 18-digit number.
+Next, for each of your players, add their corresponding Discord ID (Not UserName#1234, Right click them in Discord and select "Copy ID" at the bottom) to their User Configuration view. This will be a 17 to 19-digit number.
 
 ## Usage
 There are two ways to forward messages to discord:

--- a/lang/en.json
+++ b/lang/en.json
@@ -16,7 +16,7 @@
    "DISCORDINTEGRATION.GMNotificationsLabel" : "Receive GM Discord Notifications?",
    "DISCORDINTEGRATION.TokenControlsButtonTooltip" : "Enable/Disable forwarding chat messages to Discord",
 
-   "DISCORDINTEGRATION.InvalidIdError" : "The Discord ID provided is invalid. It should be a 17 or 18 digit number.",
+   "DISCORDINTEGRATION.InvalidIdError" : "The Discord ID provided is invalid. It should be a 17 to 19 digit number.",
 
    "DISCORDINTEGRATION.CouldNotSendMessage" : "Could not send Discord message: ",
 

--- a/src/DiscordIntegration.ts
+++ b/src/DiscordIntegration.ts
@@ -6,8 +6,8 @@ import { ActorData } from "@league-of-foundry-developers/foundry-vtt-types/src/f
 let gameUsers: StoredDocument<User>[];
 let foundryGame: Game;
 
-// Discord user-ids are either 17 or 18 digits.
-const DISCORD_MAX_ID_LENGTH = 18;
+// Discord user-ids are between 17 and 19 digits.
+const DISCORD_MAX_ID_LENGTH = 19;
 const DISCORD_MIN_ID_LENGTH = 17;
 
 // Element IDs

--- a/tests/DiscordIntegrationTests.spec.ts
+++ b/tests/DiscordIntegrationTests.spec.ts
@@ -188,11 +188,11 @@ test.describe('discord-integration', () => {
 
         });
 
-        test('when discord-id-config input is not a 17- or 18-digit number', async ({ page }) => {
+        test('when discord-id-config input is not a 17 to 19-digit number', async ({ page }) => {
             await logOnAsUser(PLAYER_INDEX.GAMEMASTER, page);
             await testInvalidInput('not an 18-digit nu', page);
             await testInvalidInput('1234567891234567', page);
-            await testInvalidInput('1234567891234567891', page);
+            await testInvalidInput('12345678912345678912', page);
         });
 
         /**


### PR DESCRIPTION
In addition to 17 and 18 digit IDs, Discord has used 19-digit IDs for new users since around July 2022. Some of my players have 19-digit IDs and can't use this module as a result. This change modifies the max length from 18 to 19 across the main code, test, English localization, and README files, allowing newer Discord users to use this module.